### PR TITLE
Migrate notes

### DIFF
--- a/client/src/components/EmailDialog.vue
+++ b/client/src/components/EmailDialog.vue
@@ -15,9 +15,9 @@ export default {
       type: Boolean,
       required: true
     },
-    note: {
-      type: String,
-      default: ""
+    notes: {
+      type: Array,
+      default: () => []
     }
   },
   data: () => ({
@@ -61,7 +61,7 @@ export default {
         this.initialize();
       }
     },
-    note(value) {
+    notes(value) {
       if (value) {
         this.initialize();
       }
@@ -112,11 +112,16 @@ export default {
       this.subject = experiment;
       this.body = `Experiment: ${this.currentSession.experiment}
 Scan: ${this.currentSession.name}`;
-      if (this.note) {
+      if (this.notes) {
         this.body = `${this.body}
-Note:
-${this.note}
+Notes:`;
+        for (let i = 0; i < this.notes.length; i++) {
+          let note = this.notes[i];
+          this.body = `${this.body}
+${note.creator.first_name} ${note.creator.last_name}: ${note.created}
+${note.note}
 `;
+        }
       }
       this.initialized = true;
     },

--- a/client/src/components/EmailDialog.vue
+++ b/client/src/components/EmailDialog.vue
@@ -114,14 +114,14 @@ export default {
 Scan: ${this.currentSession.name}`;
       if (this.notes) {
         this.body = `${this.body}
-Notes:`;
-        for (let i = 0; i < this.notes.length; i++) {
-          let note = this.notes[i];
-          this.body = `${this.body}
-${note.creator.first_name} ${note.creator.last_name}: ${note.created}
-${note.note}
+Notes:
 `;
-        }
+        this.body = this.notes
+          .map(
+            note =>
+              `${note.creator.first_name} ${note.creator.last_name}: ${note.created}\n${note.note}`
+          )
+          .join("\n");
       }
       this.initialized = true;
     },

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -16,6 +16,11 @@ const djangoClient = new Vue({
     async restoreLogin() {
       await oauthClient.maybeRestoreLogin();
       if (oauthClient.isLoggedIn) {
+        Object.assign(
+          apiClient.defaults.headers.common,
+          oauthClient.authHeaders
+        );
+
         this.user = await this.me();
       } else {
         this.login();
@@ -75,18 +80,5 @@ const djangoClient = new Vue({
     }
   }
 });
-
-// This is done with an interceptor because the value of
-// oauthClient.authHeaders is initialized asynchronously,
-// and doesn't exist at all if the user isn't logged in.
-// Using client.defaults.headers.common.Authorization = ...
-// would not update when the headers do.
-apiClient.interceptors.request.use(config => ({
-  ...config,
-  headers: {
-    ...oauthClient.authHeaders,
-    ...config.headers
-  }
-}));
 
 export default djangoClient;

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -64,4 +64,17 @@ const djangoClient = new Vue({
   }
 });
 
+// This is done with an interceptor because the value of
+// oauthClient.authHeaders is initialized asynchronously,
+// and doesn't exist at all if the user isn't logged in.
+// Using client.defaults.headers.common.Authorization = ...
+// would not update when the headers do.
+apiClient.interceptors.request.use(config => ({
+  ...config,
+  headers: {
+    ...oauthClient.authHeaders,
+    ...config.headers
+  }
+}));
+
 export default djangoClient;

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -51,6 +51,18 @@ const djangoClient = new Vue({
       const { data } = await apiClient.get(`/scans/${scanId}`);
       return data;
     },
+    async setDecision(scanId, decision) {
+      await apiClient.post(`/scans/${scanId}/decision`, { decision });
+    },
+    async addScanNote(scanId, note) {
+      await apiClient.post("/scan_notes", {
+        scan: scanId,
+        note
+      });
+    },
+    async setScanNote(scanNoteId, note) {
+      await apiClient.put(`/scan_notes/${scanNoteId}`, { note });
+    },
     async images(scanId) {
       const { data } = await apiClient.get("/images", {
         params: { scan: scanId }

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -438,7 +438,7 @@ const store = new Vuex.Store({
             cumulativeRange: [Number.MAX_VALUE, -Number.MAX_VALUE],
             numDatasets: images.length,
             site: scan.site,
-            note: scan.note,
+            notes: scan.notes,
             decision: scan.decision,
             rating: decisionToRating(scan.decision)
             // folderId: sessionId,
@@ -491,7 +491,7 @@ const store = new Vuex.Store({
           cumulativeRange: [Number.MAX_VALUE, -Number.MAX_VALUE],
           numDatasets: images.length,
           site: scan.site,
-          note: scan.note,
+          notes: scan.notes,
           decision: scan.decision,
           rating: decisionToRating(scan.decision)
         }

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -51,8 +51,7 @@ export default {
     scanning: false,
     direction: "forward",
     advanceTimeoutId: null,
-    nextAnimRequest: null,
-    noteLastSaveTime: new Date().toISOString()
+    nextAnimRequest: null
   }),
   computed: {
     ...mapState([
@@ -79,14 +78,6 @@ export default {
       return this.sessionDatasets[this.currentSession.id];
     },
     notes() {
-      // TODO: This reference to the "lastNoteSaveTime" is here purely to get
-      // TODO: vue to re-compute the note property, since it does not naturally
-      // TODO: react to the changed "meta.note" property in the currentSession.
-      // TODO: Without this reference, when you save a new note on a scan, it
-      // TODO: gets updated in girder as well as in the currentSession, but it
-      // TODO: does not appear in the UI.  We need to figure out how to fix
-      // TODO: this properly.
-      this.noteLastSaveTime;
       if (this.currentSession) {
         return this.currentSession.notes;
       } else {
@@ -204,7 +195,6 @@ export default {
       this.currentSession.meta = meta;
       this.reviewer = meta.reviewer;
       this.reviewChanged = false;
-      this.noteLastSaveTime = new Date().toISOString();
     },
     enableEditHistroy() {
       this.editingNoteDialog = true;
@@ -223,7 +213,6 @@ export default {
       );
       this.currentSession.meta = meta;
       this.editingNoteDialog = false;
-      this.noteLastSaveTime = new Date().toISOString();
     },
     async unsavedDialogYes() {
       await this.save();

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -38,7 +38,6 @@ export default {
   inject: ["djangoRest", "userLevel"],
   data: () => ({
     newNote: "",
-    reviewer: "",
     decision: null,
     decisionChanged: false,
     unsavedDialog: false,
@@ -112,6 +111,7 @@ export default {
       if (session) {
         this.decision = session.decision;
         this.decisionChanged = false;
+        this.newNote = null;
       }
     }
   },

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -111,7 +111,7 @@ export default {
       if (session) {
         this.decision = session.decision;
         this.decisionChanged = false;
-        this.newNote = null;
+        this.newNote = "";
       }
     }
   },
@@ -220,7 +220,7 @@ export default {
       this.decisionChanged = true;
     },
     async onDecisionChanged() {
-      if (this.decision != this.currentSession.decision) {
+      if (this.decision !== this.currentSession.decision) {
         this.decisionChanged = true;
         return;
       }

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -181,20 +181,17 @@ export default {
     },
     enableEditHistroy() {
       this.editingNoteDialog = true;
-      this.editingNotes = [];
-      for (let i = 0; i < this.notes.length; i++) {
-        let note = this.notes[i];
-        this.editingNotes.push(note.note);
-      }
+      this.editingNotes = this.notes.map(note => note.note);
     },
     async saveNoteHistory() {
-      for (let i = 0; i < this.editingNotes.length; i++) {
-        let editingNote = this.editingNotes[i];
-        let note = this.notes[i];
-        if (editingNote !== note.note) {
-          await this.djangoRest.setScanNote(note.id, editingNote);
-        }
-      }
+      // const modified =
+      await Promise.all(
+        this.notes
+          .filter((note, i) => note.note !== this.editingNotes[i])
+          .map((note, i) =>
+            this.djangoRest.setScanNote(note.id, this.editingNotes[i])
+          )
+      );
       this.editingNoteDialog = false;
       this.editingNotes = [];
       this.reloadScan();

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -78,7 +78,7 @@ export default {
     currentSessionDatasets() {
       return this.sessionDatasets[this.currentSession.id];
     },
-    note() {
+    notes() {
       // TODO: This reference to the "lastNoteSaveTime" is here purely to get
       // TODO: vue to re-compute the note property, since it does not naturally
       // TODO: react to the changed "meta.note" property in the currentSession.
@@ -88,24 +88,15 @@ export default {
       // TODO: this properly.
       this.noteLastSaveTime;
       if (this.currentSession) {
-        return this.currentSession.note;
-      } else {
-        return "";
-      }
-    },
-    noteSegments() {
-      if (this.currentSession && this.note) {
-        return this.note.split(/[\r\n]+/g);
+        return this.currentSession.notes;
       } else {
         return [];
       }
     },
     lastNoteTruncated() {
-      const segments = this.noteSegments;
-      if (segments.length > 0) {
-        const lastSeg = segments.slice(-1)[0];
-        console.log(`last note: ${lastSeg}`);
-        return `${lastSeg.substring(0, 32)}...`;
+      if (this.notes.length > 0) {
+        const lastNote = this.notes.slice(-1)[0];
+        return `${lastNote.note.substring(0, 32)}...`;
       }
       return "";
     }
@@ -573,7 +564,7 @@ export default {
                           text
                           small
                           icon
-                          :disabled="noteSegments.length < 1"
+                          :disabled="notes.length < 1"
                           class="ma-0"
                           v-on="on"
                           v-mousetrap="{
@@ -771,7 +762,7 @@ export default {
       </v-card>
     </v-dialog>
     <ScreenshotDialog />
-    <EmailDialog v-model="emailDialog" :note="note" />
+    <EmailDialog v-model="emailDialog" :notes="notes" />
     <KeyboardShortcutDialog v-model="keyboardShortcutDialog" />
   </v-layout>
 </template>

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -616,9 +616,9 @@ export default {
                       <v-btn
                         text
                         small
-                        value="bad"
+                        value="BAD"
                         color="red"
-                        :disabled="!newNote && !note"
+                        :disabled="!newNote && !notes"
                         v-mousetrap="{
                           bind: 'b',
                           handler: () => setDecision('BAD')
@@ -628,7 +628,7 @@ export default {
                       <v-btn
                         text
                         small
-                        value="good"
+                        value="GOOD"
                         color="green"
                         v-mousetrap="{
                           bind: 'g',
@@ -639,7 +639,7 @@ export default {
                       <v-btn
                         text
                         small
-                        value="usableExtra"
+                        value="USABLE_EXTRA"
                         color="light-green"
                         v-mousetrap="{
                           bind: 'u',


### PR DESCRIPTION
Update the notes feature on the frontend to work with the scan notes on the backend. This is complicated by the fact that in Girder we were storing all notes in one string, but in Django we are storing each individually. This is a much better UX, but makes for a much more complicated PR.

The frontend names things differently than the backend, so here is a glossary:
* nothing == django session
* web experiment == django experiment
* web session == django scan
* web dataset == django image
* web rating is 1-to-1 with django decision

This is dependent on girder/miqa#12

@venkatabhishek Could you pull down these changes and test them to make sure I didn't miss anything?